### PR TITLE
Fix release workflow to delete existing release via API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,11 +160,32 @@ jobs:
 
     - name: Delete existing release if it exists
       if: startsWith(github.ref, 'refs/tags/')
-      continue-on-error: true
-      run: |
-        gh release delete ${{ steps.version.outputs.version }} -y || true
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const tag = process.env.TAG;
+          try {
+            const release = await github.rest.repos.getReleaseByTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag
+            });
+            core.info(`Deleting existing release ${release.data.id} for tag ${tag}`);
+            await github.rest.repos.deleteRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: release.data.id
+            });
+          } catch (error) {
+            if (error.status === 404) {
+              core.info(`No existing release found for tag ${tag}`);
+            } else {
+              throw error;
+            }
+          }
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ steps.version.outputs.version }}
 
     - name: Release AppImage
       if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Summary
- replace the shell-based release deletion step with actions/github-script
- call the GitHub Releases API to remove any existing release before uploading new assets

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e2802fa6f483278b0d31bb464ce64e